### PR TITLE
Fix BlueprintsRoot in RT not being loaded + Make sort order proper

### DIFF
--- a/BlueprintExplorer/BlueprintDB.cs
+++ b/BlueprintExplorer/BlueprintDB.cs
@@ -396,7 +396,6 @@ namespace BlueprintExplorer
                 var assName = new AssemblyName(args.Name);
 
                 var dir = Path.GetDirectoryName(args.RequestingAssembly.Location);
-
                 var assFile = Directory.EnumerateFiles(dir, "*.dll")
                     .Where(assFile => Path.GetFileNameWithoutExtension(assFile) == assName.Name)
                     .FirstOrDefault();
@@ -407,17 +406,23 @@ namespace BlueprintExplorer
                 return null;
             };
 
-            if (BubblePrints.Game_Data == "WH40KRT_Data")
-                BubblePrints.Wrath = Assembly.LoadFrom(Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed", "Code.dll"));
-            else
-                BubblePrints.Wrath = Assembly.LoadFrom(Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed", "Assembly-CSharp.dll"));
+            var gamePath = Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed");
+            var resolver = new PathAssemblyResolver(Directory.EnumerateFiles(gamePath, "*.dll"));
+            var _mlc = new MetadataLoadContext(resolver);
+            if (BubblePrints.Game_Data == "WH40KRT_Data") 
+            {
+                BubblePrints.Wrath = _mlc.LoadFromAssemblyPath(Path.Combine(gamePath, "Code.dll"));
+            } 
+            else {
+                BubblePrints.Wrath = _mlc.LoadFromAssemblyPath(Path.Combine(gamePath, "Assembly-CSharp.dll"));
+            }
 
             var writeOptions = new JsonSerializerOptions
             {
                 WriteIndented = true,
             };
 
-            if (BubblePrints.Game_Data is "Wrath_Data" or "WH40KRT_Data")
+            if (BubblePrints.Game_Data is "Wrath_Data" or "WH40KRT_Data") 
             {
                 var assemblies = Directory
                     .EnumerateFiles(Path.GetDirectoryName(BubblePrints.Wrath.Location), "*.dll")

--- a/BlueprintExplorer/BlueprintDB.cs
+++ b/BlueprintExplorer/BlueprintDB.cs
@@ -430,7 +430,7 @@ namespace BlueprintExplorer
                     {
                         try
                         {
-                            return new [] { Assembly.LoadFrom(assFile) };
+                            return new [] { _mlc.LoadFromAssemblyPath(assFile) };
                         }
                         catch
                         {
@@ -461,6 +461,16 @@ namespace BlueprintExplorer
 
                 foreach (var type in types)
                 {
+                    foreach (var data in type.GetCustomAttributesData()) 
+                    {
+                        if (data.AttributeType.Name == typeIdType.Name) 
+                        {
+                            var guid = data.ConstructorArguments[0].Value as string;
+                            if (GuidToFullTypeName.TryAdd(guid, type.FullName))
+                                TypeGuidsInOrder.Add(guid);
+                        }
+                    }
+                    /*
                     var typeId = type.GetCustomAttribute(typeIdType);
                     if (typeId != null)
                     {
@@ -468,6 +478,7 @@ namespace BlueprintExplorer
                         if (GuidToFullTypeName.TryAdd(guid, type.FullName))
                             TypeGuidsInOrder.Add(guid);
                     }
+                    */
                 }
 
                 TypeGuidsInOrder.Sort();

--- a/BlueprintExplorer/BlueprintDB.cs
+++ b/BlueprintExplorer/BlueprintDB.cs
@@ -463,12 +463,16 @@ namespace BlueprintExplorer
                 {
                     foreach (var data in type.GetCustomAttributesData()) 
                     {
-                        if (data.AttributeType.Name == typeIdType.Name) 
+                        try 
                         {
-                            var guid = data.ConstructorArguments[0].Value as string;
-                            if (GuidToFullTypeName.TryAdd(guid, type.FullName))
-                                TypeGuidsInOrder.Add(guid);
-                        }
+                            if (data.AttributeType.Name == typeIdType.Name) 
+                            {
+                                var guid = data.ConstructorArguments[0].Value as string;
+                                if (GuidToFullTypeName.TryAdd(guid, type.FullName))
+                                    TypeGuidsInOrder.Add(guid);
+                            }
+                        } catch // Pretty sure this is some cursed attribute and not the TypeId we want
+                        { }
                     }
                     /*
                     var typeId = type.GetCustomAttribute(typeIdType);

--- a/BlueprintExplorer/BlueprintExplorer.csproj
+++ b/BlueprintExplorer/BlueprintExplorer.csproj
@@ -25,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.15" />
     <PackageReference Include="Krypton.Docking" Version="60.22.2.32" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext " Version="10.*-*" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/BlueprintExplorer/Form1.cs
+++ b/BlueprintExplorer/Form1.cs
@@ -323,12 +323,15 @@ namespace BlueprintExplorer
 
             BubblePrints.SetWrathPath(false);
 
-            if (BubblePrints.TryGetWrathPath(out var wrathPath))
+            if (BubblePrints.TryGetWrathPath(out var wrathPath)) 
             {
+                var gamePath = Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed");
+                var resolver = new PathAssemblyResolver(Directory.EnumerateFiles(gamePath, "*.dll"));
+                var _mlc = new MetadataLoadContext(resolver);
                 if (BubblePrints.CurrentGame == "RT")
-                    BubblePrints.Wrath = Assembly.LoadFrom(Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed", "Code.dll"));
+                    BubblePrints.Wrath = _mlc.LoadFromAssemblyPath(Path.Combine(gamePath, "Code.dll"));
                 else
-                    BubblePrints.Wrath = Assembly.LoadFrom(Path.Combine(wrathPath, BubblePrints.Game_Data, "Managed", "Assembly-CSharp.dll"));
+                    BubblePrints.Wrath = _mlc.LoadFromAssemblyPath(Path.Combine(gamePath, "Assembly-CSharp.dll"));
             }
 
             //blueprintViews.DrawMode = TabDrawMode.OwnerDrawFixed;

--- a/BlueprintExplorer/SplashScreenChooserJobbie.cs
+++ b/BlueprintExplorer/SplashScreenChooserJobbie.cs
@@ -26,6 +26,47 @@ namespace BlueprintExplorer
         private List<Binz> PreSort;
         private readonly Dictionary<BinzVersion, Binz> ByVersion = new();
 
+        private static int CompareTo(List<uint> a, List<uint> b) {
+            int maxLen = Math.Max(a.Count, b.Count);
+            for (int i = 0; i < maxLen; i++) {
+                uint t = (i < a.Count) ? a[i] : 0;
+                uint g = (i < b.Count) ? b[i] : 0;
+                if (t > g) {
+                    return 1;
+                }
+                if (t < g) {
+                    return -1;
+                }
+            }
+            return 0;
+        }
+        private static List<uint> GetNumifiedVersion(string version) {
+            var comps = version.Split('.');
+            var newComps = new List<uint>();
+            foreach (var comp in comps) {
+                uint num = 0;
+                foreach (var c in comp) {
+                    uint newNum = num;
+                    try {
+                        checked {
+                            if (uint.TryParse(c.ToString(), out var n)) {
+                                newNum = newNum * 10u + n;
+                            } else {
+                                int signedCharNumber = char.ToUpper(c) - ' ';
+                                uint unsignedCharNumber = (uint)Math.Max(0, Math.Min(signedCharNumber, 99));
+                                newNum = newNum * 100u + unsignedCharNumber;
+                            }
+                            num = newNum;
+                        }
+                    } catch (OverflowException) {
+                        Console.WriteLine($"Error: Encountered uint overflow while parsing version component {comp}, continuing with {num}");
+                        break;
+                    }
+                }
+                newComps.Add(num);
+            }
+            return newComps;
+        }
         public SplashScreenChooserJobbie()
         {
             InitializeComponent();
@@ -73,7 +114,7 @@ namespace BlueprintExplorer
             }
             PreSort.Sort((a, b) => {
                 var tmp = b.Version.Game.CompareTo(a.Version.Game);
-                if (tmp == 0) return a.Version.Version.CompareTo(b.Version.Version);
+                if (tmp == 0) return CompareTo(GetNumifiedVersion(a.Version.Version.ToString()), GetNumifiedVersion(b.Version.Version.ToString()));
                 else return tmp;
             });
             PreSort.ForEach(i => Available.Insert(0, i));


### PR DESCRIPTION
The BlueprintRoot not loading due to TypeError is weird, probably a dependency issue. To prevent that I opted to use the MetadataLoadContext, which does not allow actually using types, but instead is for doing metadata inspection of types.

I compared the hash of both Wrath and RT dumps using both methods; and they were the same. The new implementation can load RT BlueprintRoot. 